### PR TITLE
Update celeryconfig.py

### DIFF
--- a/cabot/celeryconfig.py
+++ b/cabot/celeryconfig.py
@@ -8,3 +8,5 @@ task_always_eager = environ_get_list(['CELERY_ALWAYS_EAGER', 'CELERY_TASK_ALWAYS
 backend = os.environ.get('CELERY_RESULT_BACKEND', None)
 
 timezone = 'UTC'
+task_soft_time_limit = 150
+worker_max_tasks_per_child = 20


### PR DESCRIPTION
Original error:
```
celery.exceptions.ImproperlyConfigured:

Cannot mix new and old setting keys, please rename the
following settings to the new format:

CELERYD_MAX_TASKS_PER_CHILD          -> worker_max_tasks_per_child
CELERYD_TASK_SOFT_TIME_LIMIT         -> task_soft_time_limit
```